### PR TITLE
Fix cumulative returns indexing in performance metrics

### DIFF
--- a/Volatility Decile Portfolio Strategy & Technical Indicators.ipynb
+++ b/Volatility Decile Portfolio Strategy & Technical Indicators.ipynb
@@ -912,7 +912,7 @@
     "    # ----- Output Info ------\n",
     "    print(\"Strategy: \", signal_name)\n",
     "    print('The Sharpe ratio is %.2f ' % sharpe_ratio)\n",
-    "    print(\"The cumulative returns is %2f\" % portfolio['cum_str_returns'][-2])\n",
+    "    print(\"The cumulative returns is %2f\" % portfolio['cum_str_returns'].iloc[-2])\n",
     "    print('The maximum drawdown is %.2f %%' % max_dd)\n",
     "    # Plot cumulative strategy returns\n",
     "    portfolio['cum_str_returns'].plot(figsize=(16,7), color='yellow')\n",
@@ -927,7 +927,7 @@
     "    plt.grid(which=\"major\", color='k', linestyle='-.', linewidth=0.2)\n",
     "    plt.show()\n",
     "    \n",
-    "    return [signal_name, sharpe_ratio, portfolio['cum_str_returns'][-2], max_dd]"
+    "    return [signal_name, sharpe_ratio, portfolio['cum_str_returns'].iloc[-2], max_dd]"
    ]
   },
   {


### PR DESCRIPTION
## Summary
- avoid label-based lookup when fetching cumulative returns from the portfolio

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b7022f4e8883209d4754dbe856aafc